### PR TITLE
Add stub crate for STARK jets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/nockvm/rust/nockvm",
     "crates/nockchain-wallet",
     "crates/zkvm-jetpack",
+    "crates/nockchain_jets",
 ]
 
 resolver = "2"

--- a/crates/nockchain_jets/Cargo.toml
+++ b/crates/nockchain_jets/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "nockchain_jets"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "nockchain_jets"
+path = "src/lib.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]

--- a/crates/nockchain_jets/src/lib.rs
+++ b/crates/nockchain_jets/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod stark;

--- a/crates/nockchain_jets/src/stark/fft.rs
+++ b/crates/nockchain_jets/src/stark/fft.rs
@@ -1,0 +1,49 @@
+#[no_mangle]
+pub extern "C" fn jet_compute_codeword_commitments(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +compute-codeword-commitments
+}
+
+#[no_mangle]
+pub extern "C" fn jet_compute_lde(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +compute-lde
+}
+
+#[no_mangle]
+pub extern "C" fn jet_compute_composition_poly(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +compute-composition-poly
+}
+
+#[no_mangle]
+pub extern "C" fn jet_compute_deep(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +compute-deep
+}
+
+#[no_mangle]
+pub extern "C" fn jet_precompute_ntts(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +precompute-ntts
+}
+
+#[no_mangle]
+pub extern "C" fn jet_build_compute_queue(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +build-compute-queue
+}
+
+#[no_mangle]
+pub extern "C" fn jet_build_jute_list(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +build-jute-list
+}
+
+#[no_mangle]
+pub extern "C" fn jet_indirect_to_bits(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +indirect-to-bits
+}
+
+#[no_mangle]
+pub extern "C" fn jet_noun_get_zero_mults(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +noun-get-zero-mults
+}
+
+#[no_mangle]
+pub extern "C" fn jet_pbkdf(_ptr: *mut u64) {
+    // TODO: implement native accelerator for +pbkdf
+}

--- a/crates/nockchain_jets/src/stark/mod.rs
+++ b/crates/nockchain_jets/src/stark/mod.rs
@@ -1,0 +1,3 @@
+pub mod fft;
+
+// TODO: add more modules for other STARK jets


### PR DESCRIPTION
## Summary
- create `nockchain_jets` crate placeholder
- wire crate into workspace
- stub out functions for STARK accelerators

## Testing
- `cargo check -p nockchain_jets` *(fails: no network to fetch toolchain)*